### PR TITLE
fix: update 404 link clients-execution.yml

### DIFF
--- a/_data/clients-execution.yml
+++ b/_data/clients-execution.yml
@@ -62,7 +62,7 @@
 - name: Nethermind
   link: http://nethermind.io/
   github: https://github.com/NethermindEth/nethermind
-  docs: https://docs.nethermind.io/nethermind/first-steps-with-nethermind/getting-started
+  docs: https://docs.nethermind.io/get-started/installing-nethermind
   chat: https://discord.com/invite/PaCMRFdvWT
   status: stable
   support: Linux, Win, macOS, ARM


### PR DESCRIPTION
Hi! I fixes a broken link in the `clients-execution.yml` file. The old link pointed to a deprecated or non-existent page for the Nethermind documentation. It has been updated to the correct and current URL.