### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/update_data_daily.yml
+++ b/.github/workflows/update_data_daily.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v2


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected