### PR TITLE
Update execution clients: EthereumJS is deprecated

### DIFF
--- a/_data/clients-execution.yml
+++ b/_data/clients-execution.yml
@@ -44,10 +44,10 @@
   github: https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/client
   docs: https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/client/docs
   chat: https://discord.gg/TNwARpR
-  status: alpha
+  status: deprecated
   support: Linux, Win, macOS
   lang: TypeScript
-  donate: funded # funded by EF
+  donate:
   opensource: true
 - name: Geth
   link: https://geth.ethereum.org/


### PR DESCRIPTION
See: https://github.com/ethereumjs/ethereumjs-monorepo/commit/7b9844fb4375e0e7cc3c06860df195b1b3185dc7

Did not test the build, just eyeballed the update.