### PR TITLE
Fix ethrex client language, add ARM support

### DIFF
--- a/_data/clients-execution.yml
+++ b/_data/clients-execution.yml
@@ -45,8 +45,8 @@
   docs: https://docs.ethrex.xyz/
   chat: https://t.me/ethrex_client
   status: stable
-  support: Linux, macOS
-  lang: Golang
+  support: Linux, macOS, ARM
+  lang: Rust
   donate: 
   opensource: true
 - name: EthereumJS


### PR DESCRIPTION
This PR changes the language of ethrex to Rust and adds [ARM support](https://github.com/lambdaclass/ethrex/pull/5465).